### PR TITLE
chore: upgrade runtime to Python 3.14 and update dev dependencies

### DIFF
--- a/.github/workflows/pytest.yml
+++ b/.github/workflows/pytest.yml
@@ -17,10 +17,10 @@ jobs:
         uses: actions/checkout@v2
 
       # Setup Python environment
-      - name: Set up Python 3.13
+      - name: Set up Python 3.14
         uses: actions/setup-python@v2
         with:
-          python-version: 3.13
+          python-version: 3.14
 
       # Install Python dependencies
       - name: Install dependencies

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,27 +1,27 @@
-FROM python:3.9-slim
+FROM python:3.14-slim
 
 RUN apt-get update && \
-    apt-get install -y libpq-dev gcc postgresql-client
+    apt-get install -y --no-install-recommends libpq-dev gcc libc6-dev postgresql-client-17 && \
+    rm -rf /var/lib/apt/lists/*
 
 #================================================================
 # pip install required modules
 #================================================================
 
-RUN pip install --upgrade setuptools
-ADD requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt
+COPY requirements.txt /tmp/requirements.txt
+RUN pip install --no-cache-dir --upgrade pip setuptools && \
+    pip install --no-cache-dir -r /tmp/requirements.txt
 
 #==================================================
 # Add the latest code
 #==================================================
 
-RUN mkdir -p /pgevents
 WORKDIR /pgevents
 
-ADD . /pgevents
+COPY . .
 
 # Make health check script executable
 RUN chmod +x /pgevents/producer/health_check.sh
 
-RUN pip install -e .
+RUN pip install --no-cache-dir -e .
 CMD ["/bin/bash"]

--- a/dev/postgres/Dockerfile
+++ b/dev/postgres/Dockerfile
@@ -1,6 +1,6 @@
-FROM postgres:12
+FROM postgres:17
 
-RUN export PATH=/usr/lib/postgresql/12/bin:$PATH
+RUN export PATH=/usr/lib/postgresql/17/bin:$PATH
 
 # Copy the database initialization script:
 COPY ./fixtures/* /docker-entrypoint-initdb.d/
@@ -9,5 +9,5 @@ COPY ./init-pgconf.sh /docker-entrypoint-initdb.d/init-pgconf.sh
 # Install wal2json
 RUN apt-get update \
     && apt-get install -y --no-install-recommends \
-        postgresql-12-wal2json \
+        postgresql-17-wal2json \
     && rm -rf /var/lib/apt/lists/*

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,6 +7,12 @@ services:
     ports:
       - '5672:5672'
       - '15672:15672'
+    healthcheck:
+      test: ["CMD", "rabbitmq-diagnostics", "-q", "ping"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     volumes:
       - rabbitmq-data:/data/
   database:
@@ -18,6 +24,12 @@ services:
       POSTGRES_PASSWORD: postgres
     ports:
       - "5432:5432"
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U $${POSTGRES_USER} -d $${POSTGRES_DB}"]
+      interval: 5s
+      timeout: 5s
+      retries: 12
+      start_period: 10s
     volumes:
       - ./:/pgevents
       - database-data:/var/lib/postgresql/data/
@@ -42,8 +54,10 @@ services:
       - ./producer:/pgevents/producer
       - ./tests:/pgevents/tests
     depends_on:
-      - database
-      - rabbitmq
+      database:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
   event_logger:
     build: .
     restart: unless-stopped
@@ -57,8 +71,10 @@ services:
     volumes:
       - ./consumer:/pgevents/consumer
     depends_on:
-      - database
-      - rabbitmq
+      database:
+        condition: service_healthy
+      rabbitmq:
+        condition: service_healthy
 volumes:
   database-data:
   rabbitmq-data:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,7 +1,6 @@
-version: '3.8'
 services:
   rabbitmq:
-    image: rabbitmq:3.8.9-management-alpine
+    image: rabbitmq:4.3.1-management-alpine
     environment:
       - RABBITMQ_DEFAULT_USER=admin
       - RABBITMQ_DEFAULT_PASS=password


### PR DESCRIPTION
## Summary

### Runtime upgrade
- Bumps base image in `Dockerfile` from `python:3.9-slim` to `python:3.14-slim` (Python 3.14 EOL: 2030-10)
- Bumps CI workflow (`pytest.yml`) from Python `3.13` to `3.14`, bringing test and production runtimes into sync

### Dockerfile improvements
- Pins `postgresql-client-17` instead of the unversioned `postgresql-client` for deterministic builds
- Adds `--no-install-recommends` to apt and clears the apt cache (`rm -rf /var/lib/apt/lists/*`) in the same layer to reduce image size; `libc6-dev` listed explicitly to satisfy psycopg2 source build requirements
- Replaces `ADD` with `COPY`, removes redundant `mkdir -p`, moves `WORKDIR` before `COPY . .`, and adds `--no-cache-dir` to all pip calls
- Upgrades both `pip` and `setuptools` in a single `RUN` layer before installing dependencies

### Dev environment
- Removes obsolete `version` attribute from `docker-compose.yaml`
- Bumps RabbitMQ from `3.8.9-management-alpine` to `4.3.1-management-alpine` in `docker-compose.yaml`
- Bumps PostgreSQL from `12` to `17` in `dev/postgres/Dockerfile`, updating PATH and wal2json package accordingly
- Adds RabbitMQ and Postgres healthchecks and updates `producer` / `event_logger` to wait for healthy dependencies before startup, avoiding transient AMQP connection errors
